### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask-Bootstrap==3.3.6.0
 Flask-Heroku==0.1.9
 Flask-Debugtoolbar==0.10.0
 Flask-WTF==0.12
+lxml==3.5.0
 goose-extractor==1.0.25
 ipython==5.0.0
 Flask-Assets==0.11


### PR DESCRIPTION
Couldn't install the latest lxml on OS X 10.11.6 so had to specify the particular version (it is used by goose-extractor which is pretty dated anyway)